### PR TITLE
lib/xenstore: preserve logging from Xs_client_unix

### DIFF
--- a/lib/xenstore.ml
+++ b/lib/xenstore.ml
@@ -15,6 +15,7 @@
 module Client = Xs_client_unix.Client(Xs_transport_unix_client)
 let make_client () =
 	try
+		Client.set_logger (fun s -> Logs.debug (fun m -> m "Xs_client_unix: %s" s));
 		Client.make ()
 	with e ->
 		Logs.err (fun m -> m "Failed to connect to xenstore. The raw error was: %s" (Printexc.to_string e));


### PR DESCRIPTION
Why wouldn't you want to see what Xs_client_unix is trying to log?