### PR TITLE
RFC: move Xenstore_watch into ezxenstore

### DIFF
--- a/lib/jbuild
+++ b/lib/jbuild
@@ -1,11 +1,12 @@
 (library
  ((name ezxenstore)
   (public_name ezxenstore)
-  (modules (xenstore watch))
   (wrapped false)
   (libraries (cmdliner
               logs
               threads
-              xenstore.unix
-              xenstore_transport.unix))
+              xcp
+              xenctrl
+              xenstore_transport.unix
+              xenstore.unix))
  ))

--- a/lib/watch.ml
+++ b/lib/watch.ml
@@ -24,11 +24,11 @@ type 'a t = { evaluate: Xs.xsh -> 'a }
 
 let map f x = { evaluate = fun xs -> f (x.evaluate xs) }
 
-let has_fired ~xs x =
+let has_fired x =
   try Xenstore.with_xs (fun h -> x.evaluate h); true with Xs_protocol.Eagain -> false 
 
 (** Block waiting for a result *)
-let wait_for ~xs ?(timeout=300.) (x: 'a t) =
+let wait_for ?(timeout=300.) (x: 'a t) =
   let with_pipe f =
     let (p1,p2) = Unix.pipe () in
     let close_all () =

--- a/lib/xenctrl_uuid.ml
+++ b/lib/xenctrl_uuid.ml
@@ -13,17 +13,17 @@
  *)
 
 let bytes_of_handle h =
-  let s = String.make 16 '\000' in
+  let s = Bytes.make 16 '\000' in
   for i = 0 to 15 do
-    s.[i] <- char_of_int h.(i)
+    Bytes.set s i (char_of_int h.(i))
   done;
   s
 
 let uuid_of_handle h =
-  let h' = bytes_of_handle h in
+  let h' = bytes_of_handle h |> Bytes.to_string in
   match Uuidm.of_bytes h' with
   | Some x -> x
-  | None -> failwith (Printf.sprintf "VM handle '%s' is in invalid uuid" h')
+  | None -> failwith (Printf.sprintf "VM handle '%s' is an invalid uuid" h')
 
 let handle_of_uuid u =
   let s = Uuidm.to_bytes u in

--- a/lib/xenctrl_uuid.ml
+++ b/lib/xenctrl_uuid.ml
@@ -1,0 +1,35 @@
+(*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+let bytes_of_handle h =
+  let s = String.make 16 '\000' in
+  for i = 0 to 15 do
+    s.[i] <- char_of_int h.(i)
+  done;
+  s
+
+let uuid_of_handle h =
+  let h' = bytes_of_handle h in
+  match Uuidm.of_bytes h' with
+  | Some x -> x
+  | None -> failwith (Printf.sprintf "VM handle '%s' is in invalid uuid" h')
+
+let handle_of_uuid u =
+  let s = Uuidm.to_bytes u in
+  let h = Array.make 16 0 in
+  for i = 0 to 15 do
+    h.(i) <- int_of_char s.[i]
+  done;
+  h
+

--- a/lib/xenstore_watch.ml
+++ b/lib/xenstore_watch.ml
@@ -1,0 +1,171 @@
+(*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+open Xenstore
+open Xenops_helpers
+open Xenops_utils
+
+module D = Debug.Make(struct let name = "xenstore_watch" end)
+open D
+
+exception Watch_overflow
+
+let _introduceDomain = "@introduceDomain"
+let _releaseDomain = "@releaseDomain"
+
+module IntMap = Map.Make(struct type t = int let compare = compare end)
+module IntSet = Set.Make(struct type t = int let compare = compare end)
+
+module type WATCH_ACTIONS = sig
+  val watch_token : int -> string
+  val interesting_paths_for_domain : int -> string -> string list
+  val watch_fired : Xenctrl.handle -> Xenstore.Xs.xsh -> string -> Xenctrl.domaininfo IntMap.t -> IntSet.t -> unit
+  val unmanaged_domain : int -> string -> bool
+  val found_running_domain : int -> string -> unit
+  val domain_appeared : Xenctrl.handle -> Xenstore.Xs.xsh -> int -> unit
+  val domain_disappeared : Xenctrl.handle -> Xenstore.Xs.xsh -> int -> unit
+end
+
+let watch ~xs token path =
+  debug "xenstore watch path=%s token=%s" path token;
+  try
+    xs.Xs.watch path token
+  with Xs_protocol.Eexist ->
+    debug "xenstore watch on %s threw Xs_protocol.Eexist" path
+
+
+let unwatch ~xs token path =
+  try
+    debug "xenstore unwatch path=%s token=%s" path token;
+    xs.Xs.unwatch path token
+  with Xs_protocol.Enoent _ ->
+    debug "xenstore unwatch %s threw Xs_protocol.Enoent" path
+
+let uuid_of_di di = Xenctrl_uuid.uuid_of_handle di.Xenctrl.handle
+
+module WatchXenstore = functor(Actions: WATCH_ACTIONS) -> struct
+
+  let list_domains xc =
+    let dis = Xenctrl.domain_getinfolist xc 0 in
+    let ids = List.map (fun x -> x.Xenctrl.domid) dis in
+    debug "Current domains: %s" (String.concat ", " (List.map string_of_int ids));
+    List.fold_left (fun map (k, v) -> IntMap.add k v map) IntMap.empty (List.combine ids dis)
+
+  let domain_looks_different a b = match a, b with
+    | None, Some _ -> true
+    | Some _, None -> true
+    | None, None -> false
+    | Some a', Some b' ->
+      let open Xenctrl in
+      a'.shutdown <> b'.shutdown
+      || (a'.shutdown && b'.shutdown && (a'.shutdown_code <> b'.shutdown_code))
+
+  let list_different_domains a b =
+    let c = IntMap.merge (fun _ a b -> if domain_looks_different a b then Some () else None) a b in
+    List.map fst (IntMap.bindings c)
+
+  let watch_xenstore () =
+    let xc = Xenctrl.interface_open () in
+    try
+      with_xs
+        (fun xs ->
+           let domains = ref IntMap.empty in
+           let watches = ref IntSet.empty in
+           let uuids = ref IntMap.empty in
+
+           let add_watches_for_domain xs domid uuid =
+             debug "Adding watches for: domid %d" domid;
+             Actions.domain_appeared xc xs domid;
+             let token = Actions.watch_token domid in
+             List.iter (watch ~xs token) (Actions.interesting_paths_for_domain domid uuid);
+             uuids := IntMap.add domid uuid !uuids;
+             watches := IntSet.add domid !watches in
+
+           let remove_watches_for_domain xs domid =
+             debug "Removing watches for: domid %d" domid;
+             Actions.domain_disappeared xc xs domid;
+             if IntMap.mem domid !uuids then begin
+               let uuid = IntMap.find domid !uuids in
+               let token = Actions.watch_token domid in
+               List.iter (unwatch ~xs token) (Actions.interesting_paths_for_domain domid uuid);
+               watches := IntSet.remove domid !watches;
+               uuids := IntMap.remove domid !uuids;
+             end in
+
+           let look_for_different_domains () =
+             let domains' = list_domains xc in
+             let different = list_different_domains !domains domains' in
+             List.iter
+               (fun domid ->
+                  let open Xenctrl in
+                  debug "Domain %d may have changed state" domid;
+                  (* The uuid is either in the new domains map or the old map. *)
+                  let di = IntMap.find domid (if IntMap.mem domid domains' then domains' else !domains) in
+                  let id = Uuidm.to_string (uuid_of_di di) in
+                  if Actions.unmanaged_domain domid id
+                  then begin
+                    debug "However domain %d is not managed by us: ignoring" domid;
+                    if IntMap.mem domid !uuids then begin
+                      debug "Cleaning-up the remaining watches for: domid %d" domid;
+                      remove_watches_for_domain xs domid;
+                    end;
+                  end else begin
+                    Actions.found_running_domain domid id;
+                    (* A domain is 'running' if we know it has not shutdown *)
+                    let running = IntMap.mem domid domains' && (not (IntMap.find domid domains').shutdown) in
+                    match IntSet.mem domid !watches, running with
+                    | true, true -> () (* still running, nothing to do *)
+                    | false, false -> () (* still offline, nothing to do *)
+                    | false, true ->
+                      add_watches_for_domain xs domid id
+                    | true, false ->
+                      remove_watches_for_domain xs domid
+                  end
+               ) different;
+             domains := domains' in
+
+           let process_one_watch c (path, token) =
+             if path = _introduceDomain || path = _releaseDomain
+             then look_for_different_domains ()
+             else 
+               Client.immediate c (fun h -> 
+                   let xs = Xs.ops h in
+                   Actions.watch_fired xc xs path !domains !watches) in
+
+           let register_for_watches () =
+             let c = get_client () in
+             Client.immediate c
+               (fun xs ->
+                  Client.set_watch_callback c (process_one_watch c);
+                  Client.watch xs _introduceDomain "";
+                  Client.watch xs _releaseDomain "") in
+
+           debug "Starting xenstore watch thread";
+           register_for_watches ()
+        )
+    with e ->
+      debug "Caught exception attempting to watch xenstore: %s" (Printexc.to_string e);
+      Xenctrl.interface_close xc;
+      raise e
+
+  let rec create_watcher_thread () =
+    try
+      watch_xenstore ();
+    with e -> 
+      debug "watch_xenstore thread raised: %s" (Printexc.to_string e);
+      debug "watch_xenstore thread backtrace: %s" (Printexc.get_backtrace ());
+      Thread.delay 5.;
+      create_watcher_thread ()
+
+end

--- a/lib/xenstore_watch.ml
+++ b/lib/xenstore_watch.ml
@@ -13,8 +13,6 @@
  *)
 
 open Xenstore
-open Xenops_helpers
-open Xenops_utils
 
 module D = Debug.Make(struct let name = "xenstore_watch" end)
 open D
@@ -135,7 +133,7 @@ module WatchXenstore = functor(Actions: WATCH_ACTIONS) -> struct
                ) different;
              domains := domains' in
 
-           let process_one_watch c (path, token) =
+           let process_one_watch c (path, _token) =
              if path = _introduceDomain || path = _releaseDomain
              then look_for_different_domains ()
              else 


### PR DESCRIPTION
We want to move the xenstore watch module from xenopsd into this library such that we can use it from xcp-rrdd (which is using an outdated copy in xapi-xenops). I can clean up the commit history but want to make obvious what I have done so far. 