### PR TITLE
CA-277850 update ezxenstore.opam (add xenctrl)

### DIFF
--- a/ezxenstore.opam
+++ b/ezxenstore.opam
@@ -12,6 +12,7 @@ depends: [
   "jbuilder" {build}
   "cmdliner"
   "logs"
+  "xenctrl"
   "xenstore"
   "xenstore_transport"
 ]


### PR DESCRIPTION
This adds the new dependency on xenctrl to the opam file.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>