### PR TITLE
xenstore_transport.unix is deprecated

### DIFF
--- a/core/dune
+++ b/core/dune
@@ -7,6 +7,6 @@
     logs
     threads
     uuidm
-    xenstore_transport.unix
+    xenstore_transport
     xenstore.unix)
 )


### PR DESCRIPTION
There is compatibility provided at the ocamlfind level through a META file, but that won't work in a pure duniverse based build.

There is only a 'xenstore_transport' provided now.